### PR TITLE
Protect from bad zipcode

### DIFF
--- a/app/poros/new_garden.rb
+++ b/app/poros/new_garden.rb
@@ -20,12 +20,19 @@ class NewGarden
       state_code: @state_code,
       user_id: @user_id 
     )
+
     if response.has_key?(:errors)
       response[:errors].each {|error| @errors[error[:source].to_sym] = error[:detail]}
       return false
     else
       @id = response[:data][:id].to_i
-      return true
+      begin
+        GardenService.get_garden_endpoint(@id)
+      rescue JSON::ParserError
+        return false
+      else
+        return true
+      end
     end
   end
 end

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -92,4 +92,16 @@ RSpec.describe 'new garden page' do
     expect(page).to have_content("Zip code is not a valid US postal code")
     expect(page).to have_content("Name can't be blank")
   end
+
+  it 'throws an error when zip_code correct format but has no api data', :vcr do
+    visit new_garden_path
+    
+    fill_in :name, with: "Test Garden"
+    fill_in :zip_code, with: "99999"
+    select "VT", from: :state_code
+
+    click_button "Create Garden"
+    save_and_open_page
+    expect(current_path).to eq(gardens_path)
+  end
 end

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'new garden page' do
     select "VT", from: :state_code
 
     click_button "Create Garden"
-    save_and_open_page
+
     expect(current_path).to eq(gardens_path)
   end
 end

--- a/spec/fixtures/vcr_cassettes/new_garden_page/throws_an_error_when_zip_code_correct_format_but_has_no_api_data.yml
+++ b/spec/fixtures/vcr_cassettes/new_garden_page/throws_an_error_when_zip_code_correct_format_but_has_no_api_data.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://demeter-be.herokuapp.com/api/v1/gardens
+    body:
+      encoding: UTF-8
+      string: '{"name":"Test Garden","zip_code":"99999","state_code":"VT","user_id":1}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.6.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 09 Nov 2022 13:40:57 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"95f6161212047e464183fef66defff51"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 831753d3-38d3-4014-8d9f-10c6077334f2
+      X-Runtime:
+      - '0.064925'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"13","type":"garden","attributes":{"name":"Test Garden","zip_code":"99999","state_code":"VT","user_id":1,"weather_forecast":null},"relationships":{"plots":{"data":[]}}}}'
+  recorded_at: Wed, 09 Nov 2022 13:40:58 GMT
+- request:
+    method: get
+    uri: https://demeter-be.herokuapp.com/api/v1/gardens/13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.6.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 09 Nov 2022 13:40:58 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Request-Id:
+      - 8f2d3906-e5ce-480a-be2c-8437fbab7d87
+      X-Runtime:
+      - '0.007423'
+      Content-Length:
+      - '0'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 09 Nov 2022 13:40:58 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
### Describe Features Added/Changed
Added a line of code in NewGarden poro that makes a call to the GardenService and blocks creation of a garden that would throw an app breaking error as a result of zipcode being correctly formatted but not an actual zipcode (in this case, 99999). Should send the user down the same path that other creation errors would. This probably isn't the only way to handle this, but seems to work for now?

### Describe Tests Added/Changed
Tested this saddest of paths.

### Checklist before requesting a review
- [x] Added features have thorough tests written for their functionality?
- [x] All Tests Passing?
